### PR TITLE
Develop

### DIFF
--- a/PoliticsAndWarAPIAccess/API/Implementation/NationsAPI.cs
+++ b/PoliticsAndWarAPIAccess/API/Implementation/NationsAPI.cs
@@ -16,9 +16,26 @@ namespace PoliticsAndWarAPIAccess.API.Implementation
     public NationsAPI(IRestService _service) : base (_service)
     {
     }
-    public async Task<NationsResponse> GetNations()
+    public async Task<NationsResponse> GetNations(bool? vm = null, int? allianceId = null, int? min_score = null, int? max_score = null)
     {
-      return await this.service.Get<NationsResponse>($"/nations/");
+      Dictionary<string, string> parameters = new Dictionary<string, string>();
+      if (vm != null && vm.HasValue)
+      {
+        parameters.Add("vm", vm.Value.ToString().ToLower());
+      }
+      if (allianceId != null && allianceId.HasValue)
+      {
+        parameters.Add("alliance_id", allianceId.Value.ToString());
+      }
+      if (min_score != null && min_score.HasValue)
+      {
+        parameters.Add("min_score", min_score.Value.ToString());
+      }
+      if (max_score != null && max_score.HasValue)
+      {
+        parameters.Add("max_score", max_score.Value.ToString());
+      }
+      return await this.service.Get<NationsResponse>($"/nations/", parameters);
     }
   }
 }

--- a/PoliticsAndWarAPIAccess/API/Implementation/RestService.cs
+++ b/PoliticsAndWarAPIAccess/API/Implementation/RestService.cs
@@ -1,5 +1,7 @@
 ﻿using PoliticsAndWarAPIAccess.API.Interfaces;
 using RestSharp;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -26,9 +28,16 @@ namespace PoliticsAndWarAPIAccess.API.Implementation
     /// <typeparam name="T">Model for the response to be serialized to</typeparam>
     /// <param name="resource">resource for the request</param>
     /// <returns>Task of the generic type sent in</returns>
-    public async Task<T> Get<T>(string resource) where T : class, new()
+    public async Task<T> Get<T>(string resource, Dictionary<string,string> parameters = null) where T : class, new()
     {
       var request = new RestRequest(resource);
+      if (parameters != null && parameters.Any())
+      {
+        foreach (KeyValuePair<string,string> kvp in parameters)
+        {
+          request.AddQueryParameter(kvp.Key, kvp.Value);
+        }
+      }
       var cancellationTokenSource = new CancellationTokenSource();
       request.OnBeforeDeserialization = resp => { resp.ContentType = "application/json"; };
       IRestResponse<T> response = await _client.ExecuteTaskAsync<T>(request, cancellationTokenSource.Token);

--- a/PoliticsAndWarAPIAccess/API/Interfaces/INationsAPI.cs
+++ b/PoliticsAndWarAPIAccess/API/Interfaces/INationsAPI.cs
@@ -5,6 +5,6 @@ namespace PoliticsAndWarAPIAccess.API.Interfaces
 {
   public interface INationsAPI
   {
-    Task<NationsResponse> GetNations();
+    Task<NationsResponse> GetNations(bool? vm = null, int? allianceId = null, int? min_score = null, int? max_score = null);
   }
 }

--- a/PoliticsAndWarAPIAccess/API/Interfaces/IRestService.cs
+++ b/PoliticsAndWarAPIAccess/API/Interfaces/IRestService.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace PoliticsAndWarAPIAccess.API.Interfaces
 {
   public interface IRestService
   {
-    Task<T> Get<T>(string resource) where T : class, new();
+    Task<T> Get<T>(string resource, Dictionary<string, string> parameters = null) where T : class, new();
   }
 }

--- a/PoliticsAndWarAPIAccess/API/Models/NationMilitary.cs
+++ b/PoliticsAndWarAPIAccess/API/Models/NationMilitary.cs
@@ -17,6 +17,9 @@ namespace PoliticsAndWarAPIAccess.API.Models
     public string ships { get; set; }
     public string missiles { get; set; }
     public string nukes { get; set; }
+    public string alliance { get; set; }
+    public int alliance_id { get; set; }
+    public int alliance_position { get; set; }
   }
   public class NationMilitaryResponse
   {

--- a/PoliticsAndWarAPIAccess/API/Models/Nations.cs
+++ b/PoliticsAndWarAPIAccess/API/Models/Nations.cs
@@ -14,7 +14,7 @@
     public int cities { get; set; }
     public int offensivewars { get; set; }
     public int defensivewars { get; set; }
-    public int score { get; set; }
+    public double score { get; set; }
     public int rank { get; set; }
     public string vacmode { get; set; }
     public int minutessinceactive { get; set; }

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/AllianceAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/AllianceAPITests.cs
@@ -46,11 +46,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<Alliance>();
-      mockRestService.Setup(x => x.Get<Alliance>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<Alliance>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new AllianceAPI(mockRestService.Object);
       var result = service.GetAlliance(1).Result;
       Assert.AreEqual(item,result);
-      mockRestService.Verify(x => x.Get<Alliance>(It.Is<string>(y => y == "/alliance/id=1")));
+      mockRestService.Verify(x => x.Get<Alliance>(It.Is<string>(y => y == "/alliance/id=1"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/AlliancesAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/AlliancesAPITests.cs
@@ -46,11 +46,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<AlliancesResponse>();
-      mockRestService.Setup(x => x.Get<AlliancesResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<AlliancesResponse>(It.IsAny<string>(),null)).Returns(Task.FromResult(item));
       var service = new AlliancesAPI(mockRestService.Object);
       var result = service.GetAlliances().Result;
       Assert.AreEqual(item,result);
-      mockRestService.Verify(x => x.Get<AlliancesResponse>(It.Is<string>(y => y == "/alliances/")));
+      mockRestService.Verify(x => x.Get<AlliancesResponse>(It.Is<string>(y => y == "/alliances/"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/ApplicantAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/ApplicantAPITests.cs
@@ -46,11 +46,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<ApplicantResponse>();
-      mockRestService.Setup(x => x.Get<ApplicantResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<ApplicantResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new ApplicantAPI(mockRestService.Object);
       var result = service.GetApplicant(4124).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<ApplicantResponse>(It.Is<string>(y => y == "/applicants/4124")));
+      mockRestService.Verify(x => x.Get<ApplicantResponse>(It.Is<string>(y => y == "/applicants/4124"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/CityAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/CityAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<City>();
-      mockRestService.Setup(x => x.Get<City>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<City>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new CityAPI(mockRestService.Object);
       var result = service.GetCity(4124).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<City>(It.Is<string>(y => y == "/city/id=4124")));
+      mockRestService.Verify(x => x.Get<City>(It.Is<string>(y => y == "/city/id=4124"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/NationAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/NationAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<Nation>();
-      mockRestService.Setup(x => x.Get<Nation>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<Nation>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new NationAPI(mockRestService.Object);
       var result = service.GetNation(4124).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<Nation>(It.Is<string>(y => y == "/nation/id=4124")));
+      mockRestService.Verify(x => x.Get<Nation>(It.Is<string>(y => y == "/nation/id=4124"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/NationMilitaryAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/NationMilitaryAPITests.cs
@@ -1,0 +1,47 @@
+﻿using AutoFixture;
+using Moq;
+using NUnit.Framework;
+using PoliticsAndWarAPIAccess.API.Implementation;
+using PoliticsAndWarAPIAccess.API.Interfaces;
+using PoliticsAndWarAPIAccess.API.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
+{
+  [TestFixture()]
+  public class NationMilitaryAPITests
+  {
+    Mock<IRestService> mockRestService;
+    [SetUp]
+    public void SetUp()
+    {
+      mockRestService = new Mock<IRestService>();
+    }
+    [Test()]
+    public void NationMilitaryAPITest()
+    {
+    }
+
+    [Test()]
+    public void NationMilitaryAPITest1()
+    {
+    }
+
+    [Test()]
+    public async Task GetNationMilitaryTest()
+    {
+      Fixture fixture = new Fixture();
+      var item = fixture.Create<NationMilitaryResponse>();
+      mockRestService.Setup(x => x.Get<NationMilitaryResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
+
+      var service = new NationMilitaryAPI(mockRestService.Object);
+      var result = (await service.GetNationMilitary("key"));
+      Assert.AreEqual(item, result);
+      mockRestService.Verify(x => x.Get<NationMilitaryResponse>(It.Is<string>(y => y == "/nation-military/key=key"), null));
+    }
+  }
+}

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/NationsAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/NationsAPITests.cs
@@ -3,6 +3,8 @@ using Moq;
 using NUnit.Framework;
 using PoliticsAndWarAPIAccess.API.Interfaces;
 using PoliticsAndWarAPIAccess.API.Models;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
@@ -41,11 +43,41 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<NationsResponse>();
-      mockRestService.Setup(x => x.Get<NationsResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<NationsResponse>(It.IsAny<string>(), It.IsAny<Dictionary<string,string>>())).Returns(Task.FromResult(item));
       var service = new NationsAPI(mockRestService.Object);
       var result = service.GetNations().Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<NationsResponse>(It.Is<string>(y => y == "/nations/")));
+      mockRestService.Verify(x => x.Get<NationsResponse>(It.Is<string>(y => y == "/nations/"), It.IsAny<Dictionary<string, string>>()));
+    }
+    [Test()]
+    public void GetNationsVmTest()
+    {
+      Fixture fixture = new Fixture();
+      var item = fixture.Create<NationsResponse>();
+      mockRestService.Setup(x => x.Get<NationsResponse>(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>())).Returns(Task.FromResult(item));
+      var service = new NationsAPI(mockRestService.Object);
+      var result = service.GetNations(vm: true).Result;
+      Assert.AreEqual(item, result);
+      mockRestService.Verify(x => x.Get<NationsResponse>(It.Is<string>(y => y == "/nations/"), 
+          It.Is<Dictionary<string,string>>(
+            dict=> dict.First().Key == "vm" && dict.First().Value == "true")
+        )
+      );
+    }
+    [Test()]
+    public void GetNationsAllianceTest()
+    {
+      Fixture fixture = new Fixture();
+      var item = fixture.Create<NationsResponse>();
+      mockRestService.Setup(x => x.Get<NationsResponse>(It.IsAny<string>(), It.IsAny<Dictionary<string, string>>())).Returns(Task.FromResult(item));
+      var service = new NationsAPI(mockRestService.Object);
+      var result = service.GetNations(allianceId: 148).Result;
+      Assert.AreEqual(item, result);
+      mockRestService.Verify(x => x.Get<NationsResponse>(It.Is<string>(y => y == "/nations/"),
+          It.Is<Dictionary<string, string>>(
+            dict => dict.First().Key == "vm" && dict.First().Value == "true")
+        )
+      );
     }
     [Test()]
     [Category("Integration")]
@@ -55,6 +87,46 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
       var result = sut.GetNations().Result;
       Assert.IsNotNull(result);
       Assert.IsNotEmpty(result.nations);
+    }
+    [Test()]
+    [Category("Integration")]
+    public void GetNationsIntegrationVmsTest()
+    {
+      var sut = new NationsAPI();
+      var result = sut.GetNations(vm: true).Result;
+      Assert.IsNotNull(result);
+      Assert.IsNotEmpty(result.nations);
+      Assert.IsTrue(result.nations.Any(x => x.vacmode == "1"));
+    }
+    [Test()]
+    [Category("Integration")]
+    public void GetNationsIntegrationminScoreTest()
+    {
+      var sut = new NationsAPI();
+      var result = sut.GetNations(min_score: 1000).Result;
+      Assert.IsNotNull(result);
+      Assert.IsNotEmpty(result.nations);
+      Assert.IsTrue(result.nations.All(x => x.score >= 1000));
+    }
+    [Test()]
+    [Category("Integration")]
+    public void GetNationsIntegrationMaxScoreTest()
+    {
+      var sut = new NationsAPI();
+      var result = sut.GetNations(max_score: 1000).Result;
+      Assert.IsNotNull(result);
+      Assert.IsNotEmpty(result.nations);
+      Assert.IsTrue(result.nations.All(x => x.score <= 1000));
+    }
+    [Test()]
+    [Category("Integration")]
+    public void GetNationsIntegrationAllianceScoreTest()
+    {
+      var sut = new NationsAPI();
+      var result = sut.GetNations(allianceId: 0).Result;
+      Assert.IsNotNull(result);
+      Assert.IsNotEmpty(result.nations);
+      Assert.IsTrue(result.nations.All(x => x.allianceid == 0));
     }
   }
 }

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/NationsAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/NationsAPITests.cs
@@ -75,7 +75,7 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
       Assert.AreEqual(item, result);
       mockRestService.Verify(x => x.Get<NationsResponse>(It.Is<string>(y => y == "/nations/"),
           It.Is<Dictionary<string, string>>(
-            dict => dict.First().Key == "vm" && dict.First().Value == "true")
+            dict => dict.First().Key == "alliance_id" && dict.First().Value == "148")
         )
       );
     }
@@ -96,7 +96,7 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
       var result = sut.GetNations(vm: true).Result;
       Assert.IsNotNull(result);
       Assert.IsNotEmpty(result.nations);
-      Assert.IsTrue(result.nations.Any(x => x.vacmode == "1"));
+      Assert.IsTrue(result.nations.Any(x => x.vacmode != "0"));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/TradeHistoryAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/TradeHistoryAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<TradeHistoryResponse>();
-      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new TradeHistoryAPI(mockRestService.Object);
       var result = service.GetTradeHistory("test",new Resources[] { Resources.steel}).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel&records=10000")));
+      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel&records=10000"), null));
     }
 
     [Test()]
@@ -53,11 +53,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<TradeHistoryResponse>();
-      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new TradeHistoryAPI(mockRestService.Object);
       var result = service.GetTradeHistory("test", new Resources[] { Resources.steel, Resources.oil }).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel,oil&records=10000")));
+      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel,oil&records=10000"), null));
     }
 
     [Test()]
@@ -65,11 +65,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<TradeHistoryResponse>();
-      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<TradeHistoryResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new TradeHistoryAPI(mockRestService.Object);
       var result = service.GetTradeHistory("test", new Resources[] { Resources.steel, Resources.oil },500).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel,oil&records=500")));
+      mockRestService.Verify(x => x.Get<TradeHistoryResponse>(It.Is<string>(y => y == "/trade-history/key=test&resources=steel,oil&records=500"), null));
     }
   }
 }

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/TradePriceAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/TradePriceAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<TradePrice>();
-      mockRestService.Setup(x => x.Get<TradePrice>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<TradePrice>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new TradePriceAPI(mockRestService.Object);
       var result = service.GetTradePrice(Resources.bauxite).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<TradePrice>(It.Is<string>(y => y == "/tradeprice/resource=bauxite")));
+      mockRestService.Verify(x => x.Get<TradePrice>(It.Is<string>(y => y == "/tradeprice/resource=bauxite"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/WarAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/WarAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<WarResponse>();
-      mockRestService.Setup(x => x.Get<WarResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<WarResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new WarAPI(mockRestService.Object);
       var result = service.GetWar(1).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<WarResponse>(It.Is<string>(y => y == "/war/1")));
+      mockRestService.Verify(x => x.Get<WarResponse>(It.Is<string>(y => y == "/war/1"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/API/Implementation/WarsAPITests.cs
+++ b/PoliticsAndWarAPIAccessTests/API/Implementation/WarsAPITests.cs
@@ -41,11 +41,11 @@ namespace PoliticsAndWarAPIAccess.API.Implementation.Tests
     {
       Fixture fixture = new Fixture();
       var item = fixture.Create<WarsResponse>();
-      mockRestService.Setup(x => x.Get<WarsResponse>(It.IsAny<string>())).Returns(Task.FromResult(item));
+      mockRestService.Setup(x => x.Get<WarsResponse>(It.IsAny<string>(), null)).Returns(Task.FromResult(item));
       var service = new WarsAPI(mockRestService.Object);
       var result = service.GetWars(1).Result;
       Assert.AreEqual(item, result);
-      mockRestService.Verify(x => x.Get<WarsResponse>(It.Is<string>(y => y == "/wars/1")));
+      mockRestService.Verify(x => x.Get<WarsResponse>(It.Is<string>(y => y == "/wars/1"), null));
     }
     [Test()]
     [Category("Integration")]

--- a/PoliticsAndWarAPIAccessTests/PoliticsAndWarAPIAccessTests.csproj
+++ b/PoliticsAndWarAPIAccessTests/PoliticsAndWarAPIAccessTests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="API\Implementation\ApplicantAPITests.cs" />
     <Compile Include="API\Implementation\CityAPITests.cs" />
     <Compile Include="API\Implementation\NationAPITests.cs" />
+    <Compile Include="API\Implementation\NationMilitaryAPITests.cs" />
     <Compile Include="API\Implementation\NationsAPITests.cs" />
     <Compile Include="API\Implementation\TradeHistoryAPITests.cs" />
     <Compile Include="API\Implementation\TradePriceAPITests.cs" />


### PR DESCRIPTION
-Added alliance information to the nation military API page
-Nations API now defaults to not including Vacation Mode nations, they can be included by appending "vm=true" in the URL
-Nations API now lets you filter to a single alliance if you want by appending "alliance_id=ID" in the URL
-Nations API now lets you set a minimum score threshold if you want by appending "min_score=X" in the URL
-Nations API now lets you set a maximum score threshold if you want by appending "max_score=X" in the URL